### PR TITLE
Add species to particle problems constructors, rework sources and loaders

### DIFF
--- a/examples/townsend_coefficient.jl
+++ b/examples/townsend_coefficient.jl
@@ -1,0 +1,63 @@
+import PlasmaModelingToolkit.Domains: OneDimensionalDomain
+import PlasmaModelingToolkit.Models: FDMModel, PICModel, MCCModel
+import PlasmaModelingToolkit.Problems: BoundaryValueProblem, ParticleCollisionProblem
+import PlasmaModelingToolkit.BoundaryConditions: DirichletBoundaryCondition
+import PlasmaModelingToolkit.ParticleBoundaries: AbsorbingBoundary
+import PlasmaModelingToolkit.Distributions: UniformDistribution, MaxwellBoltzmannDistribution
+import PlasmaModelingToolkit.Collisions: Collision
+import PlasmaModelingToolkit.CrossSections: Biagi
+import PlasmaModelingToolkit.Collisions: ElasticCollision, IonizationCollision, ExcitationCollision
+import PlasmaModelingToolkit.Sources: ParticleLoader, FluidLoader
+import PlasmaModelingToolkit.Geometry: Segment1D, Point1D
+import PlasmaModelingToolkit.Materials: Vacuum
+import PlasmaModelingToolkit.Species: electrons, ions, gas
+import PlasmaModelingToolkit.Units: ps, torr, Td, cm
+import PlasmaModelingToolkit.Atoms: Helium
+import PlasmaModelingToolkit.Constants: ε_0, kB
+
+V = 160.0               # voltage (V)
+T = 300.0               # temperature (K)
+P = 21.2torr            # pressure (Pa)
+E = 212e3               # electric field (V/m)
+n_0 = P / (T * kB)      # number density (1/m^3)
+N_e = 100_000           # number of electrons
+L = V / E               # domain length
+n_e = N_e * 1000/L      # electron density in source
+N = 129                 # grid points
+
+domain = OneDimensionalDomain(0.0, L, Vacuum())
+
+anode = Point1D(0.0)
+cathode = Point1D(L)
+whole = Segment1D(0, L)
+source = Segment1D(0, L/1000)
+
+bvp = BoundaryValueProblem(domain)
+bvp[anode] = DirichletBoundaryCondition(0)
+bvp[cathode] = DirichletBoundaryCondition(V)
+
+e   = electrons()
+He  = gas(Helium)
+iHe = ions(Helium)
+
+problem = ParticleCollisionProblem(domain, e, He, iHe)
+
+problem[anode] = AbsorbingBoundary()
+problem[cathode] = AbsorbingBoundary()
+
+problem[source] = ParticleLoader(e, N_e, UniformDistribution())
+problem[whole] = FluidLoader(He, n_0, T)
+
+problem += ElasticCollision(e, He, Biagi(version=8.97); scattering=:Vahedi)
+problem += ExcitationCollision(e, He, Biagi(version=8.97); ε_loss=19.82, scattering=:Isotropic)
+problem += ExcitationCollision(e, He, Biagi(version=8.97); ε_loss=20.62, scattering=:Isotropic)
+problem += ExcitationCollision(e, He, Biagi(version=8.97); ε_loss=20.96, scattering=:Isotropic)
+problem += ExcitationCollision(e, He, Biagi(version=8.97); ε_loss=21.22, scattering=:Isotropic)
+problem += ExcitationCollision(e, He, Biagi(version=8.97); ε_loss=23.087, scattering=:Isotropic)
+problem += IonizationCollision(e, He, Biagi(version=8.97); ε_loss=24.5874, scattering=:Opal, ions=iHe)
+
+fdm = FDMModel(bvp, N)
+pic = PICModel(problem, N;
+    weights=tuple(e => 1.0, iHe => 1.0),
+    maxcount=tuple(e => 5N_e, iHe => 4N_e));
+mcc = MCCModel(problem);

--- a/examples/turner2013-case-1.jl
+++ b/examples/turner2013-case-1.jl
@@ -5,19 +5,16 @@ import PlasmaModelingToolkit.BoundaryConditions: DirichletBoundaryCondition
 import PlasmaModelingToolkit.ParticleBoundaries: AbsorbingBoundary
 import PlasmaModelingToolkit.Problems: BoundaryValueProblem, ParticleCollisionProblem
 import PlasmaModelingToolkit.Models: FDMModel, PICModel, MCCModel
-import PlasmaModelingToolkit.Species: electrons, ions, gas
-import PlasmaModelingToolkit.Sources: SpeciesLoader
-import PlasmaModelingToolkit.TemporalFunctions: SineFunction, ConstantFunction
+import PlasmaModelingToolkit.Species: Particles, Fluid
+import PlasmaModelingToolkit.Sources: ParticleLoader, FluidLoader
+import PlasmaModelingToolkit.TemporalFunctions: CosineFunction, ConstantFunction
 import PlasmaModelingToolkit.Collisions: ElasticCollision, IonizationCollision, ExcitationCollision, IsotropicScattering, BackwardScattering
 import PlasmaModelingToolkit.Distributions: UniformDistribution, MaxwellBoltzmannDistribution
 import PlasmaModelingToolkit.Atoms: Helium
 import PlasmaModelingToolkit.Units: MHz, cm
 import PlasmaModelingToolkit.CrossSections: Biagi, Phelps
 
-DATASET_PATH = "./data"
-
 const X    = 6.7cm                    # electrode separation
-const R    = √(1/π)                   # electrode radius
 const n_He = 9.64e20                  # neutral density
 const T_He = 300.0                    # neutral temperature
 const FREQ = 13.56MHz                 # RF frequency
@@ -25,12 +22,10 @@ const VOLT = 450.0                    # voltage
 
 const n_0 = 2.56e14                   # plasma density
 const T_e = 30_000.0                  # electron temperature
-const T_i = 300.0                     # ion temperature
 const N_C = 512                       # particles per cell
 
 const NX = 128                        # number of cells
-const WG = (n_0 * X * π * R^2) / 
-       (N_C * NX)                     # weight
+const WG = (n_0 * X) / (N_C * NX)     # weight
 
 const Δt  = 1 / 400FREQ
 const N_S = 512_000
@@ -43,29 +38,30 @@ anode   = Point1D(X)
 whole   = Segment1D(0.0, X)
 
 bvp = BoundaryValueProblem(domain)
-bvp[cathode] = DirichletBoundaryCondition(SineFunction{VOLT, FREQ}())
+bvp[cathode] = DirichletBoundaryCondition(CosineFunction{VOLT, FREQ}())
 bvp[anode]   = DirichletBoundaryCondition(ConstantFunction{0.0}())
 
-e   = electrons()
-iHe = ions(Helium)
-He  = gas(Helium)
+e   = Particles{:e}(-1.60217662e-19, 9.109e-31)
+iHe = Particles{:iHe}(1.60217662e-19, 6.67e-27)
+He  = Fluid{:He}(6.67e-27)
 
-problem = ParticleCollisionProblem(domain)
+problem = ParticleCollisionProblem(domain, e, iHe, He)
 problem[cathode] = AbsorbingBoundary(e, iHe)
 problem[anode]   = AbsorbingBoundary(e, iHe)
 
-problem[whole] = SpeciesLoader(e, n_0,   UniformDistribution(), MaxwellBoltzmannDistribution{T_e, e.mass}())
-problem[whole] = SpeciesLoader(iHe, n_0, UniformDistribution(), MaxwellBoltzmannDistribution{T_i, iHe.mass}())
-problem[whole] = SpeciesLoader(He, n_He, UniformDistribution(), MaxwellBoltzmannDistribution{T_He, He.mass}())
+problem[whole] = ParticleLoader(e, n_0,   UniformDistribution(), MaxwellBoltzmannDistribution{T_e, e.mass}())
+problem[whole] = ParticleLoader(iHe, n_0, UniformDistribution(), MaxwellBoltzmannDistribution{T_He, iHe.mass}())
+problem[whole] = FluidLoader(He, n_He, T_He)
 
-problem += ElasticCollision(e, He, Biagi(); scattering=IsotropicScattering())
-problem += IonizationCollision(e, He, Biagi(); scattering=IsotropicScattering(), ε_loss=24.587, ions=iHe)
-problem += ExcitationCollision(e, He, Biagi(); scattering=IsotropicScattering(), ε_loss=19.82)
-problem += ExcitationCollision(e, He, Biagi(); scattering=IsotropicScattering(), ε_loss=20.061)
+problem += ElasticCollision(e, He, Biagi(version=7.1); scattering=:Isotropic)
+problem += ExcitationCollision(e, He, Biagi(version=7.1); scattering=:Isotropic, ε_loss=19.82)
+problem += ExcitationCollision(e, He, Biagi(version=7.1); scattering=:Isotropic, ε_loss=20.61)
+problem += IonizationCollision(e, He, Biagi(version=7.1); scattering=:Isotropic, ε_loss=24.587, ions=iHe)
 
-problem += ElasticCollision(iHe, He, Phelps(); scattering=IsotropicScattering())
-problem += ElasticCollision(iHe, He, Phelps(); scattering=BackwardScattering())
+problem += ElasticCollision(iHe, He, Phelps(); scattering=:Isotropic)
+problem += ElasticCollision(iHe, He, Phelps(); scattering=:Backward)
 
 es  = FDMModel(bvp, NX + 1)
 pic = PICModel(problem, NX + 1, maxcount = (e => 200_000, iHe => 200_000), weights = (e => WG, iHe => WG))
 mcc = MCCModel(problem)
+     

--- a/examples/twostreams.jl
+++ b/examples/twostreams.jl
@@ -6,7 +6,7 @@ import PlasmaModelingToolkit.ParticleBoundaries: PeriodicBoundary, ReflectingBou
 import PlasmaModelingToolkit.Problems: ParticleProblem, BoundaryValueProblem
 import PlasmaModelingToolkit.Models: FDMModel, PICModel
 import PlasmaModelingToolkit.Species: electrons, ions
-import PlasmaModelingToolkit.Sources: SpeciesLoader
+import PlasmaModelingToolkit.Sources: ParticleLoader
 import PlasmaModelingToolkit.Distributions: UniformDistribution, MaxwellBoltzmannDistribution
 import PlasmaModelingToolkit.Atoms: Helium
 import PlasmaModelingToolkit.Units: kHz
@@ -43,17 +43,17 @@ bvp[side] = NeumannBoundaryCondition()
 bvp[upper] = PeriodicBoundaryCondition()
 bvp[lower] = PeriodicBoundaryCondition()
 
-problem = ParticleProblem(domain)
+e   = electrons()
+iHe = ions(Helium)
+
+problem = ParticleProblem(domain, e, iHe)
 problem[side] = ReflectingBoundary()
 problem[lower] = PeriodicBoundary()
 problem[upper] = PeriodicBoundary()
 
-e   = electrons()
-iHe = ions(Helium)
-
-problem[whole] = SpeciesLoader(e, 0.5n_0, UniformDistribution(), MaxwellBoltzmannDistribution{T_e, e.mass}(), drift = [:z => +ν_drift])
-problem[whole] = SpeciesLoader(e, 0.5n_0, UniformDistribution(), MaxwellBoltzmannDistribution{T_e, e.mass}(), drift = [:z => -ν_drift])
-problem[whole] = SpeciesLoader(iHe, n_0, UniformDistribution(), MaxwellBoltzmannDistribution{T_i, iHe.mass}())
+problem[whole] = ParticleLoader(e, 0.5n_0, UniformDistribution(), MaxwellBoltzmannDistribution{T_e, e.mass}(), drift = [:z => +ν_drift])
+problem[whole] = ParticleLoader(e, 0.5n_0, UniformDistribution(), MaxwellBoltzmannDistribution{T_e, e.mass}(), drift = [:z => -ν_drift])
+problem[whole] = ParticleLoader(iHe, n_0, UniformDistribution(), MaxwellBoltzmannDistribution{T_i, iHe.mass}())
 
 es  = FDMModel(bvp, NZ + 1, NR + 1)
 pic = PICModel(problem, NZ + 1, NR + 1, weights = (e => WG, iHe => WG), maxcount = (e => 20_000, iHe => 20_000))

--- a/src/models/mcc.jl
+++ b/src/models/mcc.jl
@@ -13,8 +13,8 @@ struct MCCModel{D,V,CS}
 end
 
 function MCCModel(problem::ParticleCollisionProblem{D,CS}) where {D,CS}
-  particles = Set(problem.particles.particles)
-  fluids = Set(problem.fluids)
+  particles = problem.particles.particles
+  fluids = problem.fluids
   collisions = problem.collisions
   loaders = vcat(problem.loaders, problem.particles.loaders)
   return MCCModel{D,3,CS}(particles, fluids, collisions, loaders)

--- a/src/models/mcc.jl
+++ b/src/models/mcc.jl
@@ -13,17 +13,9 @@ struct MCCModel{D,V,CS}
 end
 
 function MCCModel(problem::ParticleCollisionProblem{D,CS}) where {D,CS}
-  particles = Set{Particles}()
-  fluids = Set{Fluid}()
+  particles = Set(problem.particles.particles)
+  fluids = Set(problem.fluids)
   collisions = problem.collisions
-  loaders = problem.loaders
-  for collision in collisions
-    if collision.source isa Particles
-      push!(particles, collision.source)
-    end
-    if collision.target isa Fluid
-      push!(fluids, collision.target)
-    end
-  end
+  loaders = vcat(problem.loaders, problem.particles.loaders)
   return MCCModel{D,3,CS}(particles, fluids, collisions, loaders)
 end

--- a/src/models/pic.jl
+++ b/src/models/pic.jl
@@ -4,7 +4,7 @@ import ..Problems: ParticleProblem, ParticleCollisionProblem
 import ..Grids: discretize
 import ..Species: Particles
 import ..ParticleBoundaries: ParticleBoundary
-import ..Sources: SpeciesSource, SpeciesLoader
+import ..Sources: ParticleSource, ParticleLoader
 
 struct PICModel{D,V,CS}
       grid :: Grid{D,CS}
@@ -12,55 +12,28 @@ struct PICModel{D,V,CS}
    weights :: Dict{Particles, Float64}
   maxcount :: Dict{Particles, UInt64}
 boundaries :: Vector{Pair{Shape{D}, ParticleBoundary}}
-   sources :: Vector{Pair{Shape{D}, SpeciesSource}}
-   loaders :: Vector{Pair{Shape{D}, SpeciesLoader}} 
+   sources :: Vector{Pair{Shape{D}, ParticleSource}}
+   loaders :: Vector{Pair{Shape{D}, ParticleLoader}} 
 end
 
 function PICModel(problem::ParticleProblem{D,CS}, args...; maxcount, weights) where {D,CS}
   @assert length(args) == D
 
-  grid = discretize(problem.domain, args...)
-  particles = Set{Particles}()
-  
-  for (species, _) in maxcount
-    if species in particles
-      @warn "Repeated $(species) in maxcount definition. The last value applies."
-    elseif species isa Particles
-      push!(particles, species)
-    end
-  end
+  @assert all(x->(x in problem.particles), first.(maxcount)) "Unknown particles in \"maxcount\" definition"
+  @assert all(x->(x in first.(maxcount)), problem.particles) "Missing definition of \"maxcount\" for some particles"
 
-  for (species, _) in weights
-    if species in particles
-      continue
-    elseif species isa Particles
-      @error "Unknown species $(species) (no maxcount defined for it)"
-    end
-  end
-  
+  @assert all(x->(x in problem.particles), first.(weights)) "Unknown particles in \"weights\" definition"
+  @assert all(x->(x in first.(weights)), problem.particles) "Missing definition of \"weights\" for some particles"
+
+  grid = discretize(problem.domain, args...)
+  particles = problem.particles
   weights = Dict(weights...)
   maxcount = Dict(maxcount...)
   boundaries = problem.boundaries
   sources = problem.sources
   loaders = problem.loaders
 
-  for (_, source) in sources
-    if source.species in particles
-      continue
-    elseif source.species isa Particles
-      @error "Unknown species $(source.species) (no maxcount defined for it)"
-    end
-  end
-
-  for (_, loader) in loaders
-    if loader.species in particles
-      continue
-    elseif loader.species isa Particles
-      @error "Unknown species $(loader.species) (no maxcount defined for it)"
-    end
-  end
-
-  return PICModel{D,3,CS}(grid, particles, weights, maxcount, boundaries, sources, loaders)
+  return PICModel{D,3,CS}(grid, Set(particles), weights, maxcount, boundaries, sources, loaders)
 end
 
 function PICModel(problem::ParticleCollisionProblem{D,CS}, args...; maxcount, weights) where{D,CS}

--- a/src/models/pic.jl
+++ b/src/models/pic.jl
@@ -33,7 +33,7 @@ function PICModel(problem::ParticleProblem{D,CS}, args...; maxcount, weights) wh
   sources = problem.sources
   loaders = problem.loaders
 
-  return PICModel{D,3,CS}(grid, Set(particles), weights, maxcount, boundaries, sources, loaders)
+  return PICModel{D,3,CS}(grid, particles, weights, maxcount, boundaries, sources, loaders)
 end
 
 function PICModel(problem::ParticleCollisionProblem{D,CS}, args...; maxcount, weights) where{D,CS}

--- a/src/problems/coll.jl
+++ b/src/problems/coll.jl
@@ -6,7 +6,7 @@ import Base: setindex!, +
 
 struct ParticleCollisionProblem{D, CS}
   particles :: ParticleProblem{D, CS}
-  fluids :: Vector{Fluid}
+  fluids :: Set{Fluid}
   collisions :: Vector{Collision}
   loaders :: Vector{Pair{Shape{D}, FluidLoader}}  
 end
@@ -17,7 +17,7 @@ function ParticleCollisionProblem(domain::Domain{D,CS}, species...) where {D,CS}
 
   return ParticleCollisionProblem{D, CS}(
     ParticleProblem(domain, particles...),
-    collect(fluids),
+    Set(collect(fluids)),
     [],
     [])
 end

--- a/src/problems/part.jl
+++ b/src/problems/part.jl
@@ -1,29 +1,58 @@
 import ..Domains: Domain
 import ..Geometry: Shape, Segment2D, Rectangle, Point1D, Segment1D
 import ..ParticleBoundaries: ParticleBoundary
-import ..Sources: SpeciesSource, SpeciesLoader
+import ..Sources: ParticleSource, ParticleLoader
+import ..Species: Particles, Fluid
 
 struct ParticleProblem{D, CS}
   domain :: Domain{D,CS}
+  particles :: Vector{Particles}
   boundaries :: Vector{Pair{Shape{D}, ParticleBoundary}}
-  sources :: Vector{Pair{Shape{D}, SpeciesSource}}
-  loaders :: Vector{Pair{Shape{D}, SpeciesLoader}} 
-  ParticleProblem(domain::Domain{D,CS}) where {D,CS} = new{D,CS}(domain, [], [], [])
+  sources :: Vector{Pair{Shape{D}, ParticleSource}}
+  loaders :: Vector{Pair{Shape{D}, ParticleLoader}} 
+end
+
+function ParticleProblem(domain::Domain{D,CS}, species...) where {D,CS} 
+  particles = Vector{Particles}()
+  for element in species
+    @assert element isa Particles "You can only add Particles to a ParticleProblem"
+      push!(particles, element)
+  end
+  return ParticleProblem{D,CS}(
+    domain,
+    particles,
+    [],
+    [],
+    [])
 end
 
 function setindex!(problem::ParticleProblem{2}, boundary::ParticleBoundary, segment::Segment2D)
+  if isempty(boundary.particles)
+    for species in problem.particles
+      push!(boundary.particles, species)
+    end
+  end
+  @assert all(x->(x in problem.particles), boundary.particles) "You have to add $(boundary.particles) to a problem first before adding a boundary for it"
   push!(problem.boundaries, segment => boundary)
 end
 
-function setindex!(problem::ParticleProblem{2}, source::SpeciesSource, rectangle::Rectangle)
+function setindex!(problem::ParticleProblem{2}, source::ParticleSource, rectangle::Rectangle)
+  @assert source.species in problem.particles "You have to add $(source.species) to a problem first before adding a source for it"
   push!(problem.sources, rectangle => source)
 end
 
-function setindex!(problem::ParticleProblem{2}, loader::SpeciesLoader, rectangle::Rectangle)
+function setindex!(problem::ParticleProblem{2}, loader::ParticleLoader, rectangle::Rectangle)
+  @assert loader.species in problem.particles "You have to add $(loader.species) to a problem first before adding a loader for it"
   push!(problem.loaders, rectangle => loader)
 end
 
 function setindex!(problem::ParticleProblem{1}, boundary::ParticleBoundary, point::Point1D)
+  if isempty(boundary.particles)
+    for species in problem.particles
+      push!(boundary.particles, species)
+    end
+  end
+  @assert all(x->(x in problem.particles), boundary.particles) "You have to add $(boundary.particles) to a problem first before adding a boundary for it"
   xmin = problem.domain.xmin
   xmax = problem.domain.xmax
   x, = point.coords
@@ -33,10 +62,12 @@ function setindex!(problem::ParticleProblem{1}, boundary::ParticleBoundary, poin
   push!(problem.boundaries, point => boundary)
 end
 
-function setindex!(problem::ParticleProblem{1}, source::SpeciesSource, segment::Segment1D)
+function setindex!(problem::ParticleProblem{1}, source::ParticleSource, segment::Segment1D)
+  @assert source.species in problem.particles "You have to add $(source.species) to a problem first before adding a source for it"
   push!(problem.sources, segment => source)
 end
 
-function setindex!(problem::ParticleProblem{1}, loader::SpeciesLoader, segment::Segment1D)
+function setindex!(problem::ParticleProblem{1}, loader::ParticleLoader, segment::Segment1D)
+  @assert loader.species in problem.particles "You have to add $(loader.species) to a problem first before adding a loader for it"
   push!(problem.loaders, segment => loader)
 end

--- a/src/problems/part.jl
+++ b/src/problems/part.jl
@@ -6,14 +6,14 @@ import ..Species: Particles, Fluid
 
 struct ParticleProblem{D, CS}
   domain :: Domain{D,CS}
-  particles :: Vector{Particles}
+  particles :: Set{Particles}
   boundaries :: Vector{Pair{Shape{D}, ParticleBoundary}}
   sources :: Vector{Pair{Shape{D}, ParticleSource}}
   loaders :: Vector{Pair{Shape{D}, ParticleLoader}} 
 end
 
 function ParticleProblem(domain::Domain{D,CS}, species...) where {D,CS} 
-  particles = Vector{Particles}()
+  particles = Set{Particles}()
   for element in species
     @assert element isa Particles "You can only add Particles to a ParticleProblem"
       push!(particles, element)

--- a/src/sources.jl
+++ b/src/sources.jl
@@ -36,9 +36,9 @@ struct ParticleSource <: SpeciesSource
   drift :: Vector{Pair{Symbol, Float64}}
 end
 
-struct ParticleLoader{T} <: SpeciesLoader
+struct ParticleLoader <: SpeciesLoader
   species :: Particles
-  value :: T
+  count :: Int64
   x :: PositionDistribution
   v :: VelocityDistribution
   drift :: Vector{Pair{Symbol, Float64}}
@@ -53,6 +53,6 @@ end
 ParticleSource(species::Particles, rate::TemporalFunction, x::PositionDistribution; drift=Vector{Pair{Symbol, Float64}}([])) = ParticleSource(species, rate, x, MaxwellBoltzmannDistribution{0.0, species.mass}(), drift)
 ParticleSource(species::Particles, rate::TemporalFunction, x::PositionDistribution, v::VelocityDistribution; drift=Vector{Pair{Symbol, Float64}}([])) = ParticleSource(species, rate, x, v, drift)
 
-ParticleLoader(species::Particles, value::Real, x::PositionDistribution; drift=Vector{Pair{Symbol, Float64}}([])) = ParticleLoader(species, value, x, MaxwellBoltzmannDistribution{0.0, 0.0}(), drift)
-ParticleLoader(species::Particles, value::Real, x::PositionDistribution, v::VelocityDistribution; drift=Vector{Pair{Symbol, Float64}}([])) = ParticleLoader(species, value, x, v, drift)
+ParticleLoader(species::Particles, count::Int64, x::PositionDistribution; drift=Vector{Pair{Symbol, Float64}}([])) = ParticleLoader(species, count, x, MaxwellBoltzmannDistribution{0.0, species.mass}(), drift)
+ParticleLoader(species::Particles, count::Int64, x::PositionDistribution, v::VelocityDistribution; drift=Vector{Pair{Symbol, Float64}}([])) = ParticleLoader(species, count, x, v, drift)
 end


### PR DESCRIPTION
- now all used species has to be passed to a particle problem constructor
- all particle species are stored now in `ParticleProblem` (and are used to validate further additions to the problem)
- all fluid species are stored now in `ParticleCollisionProblem` (and are used to validate further additions to the problem)
- rename `SpeciesLoader` to `ParticleLoader`
- rename `SpeciesSource` to `ParticleSource`
- `ParticleLoader` can now take number of particles as argument (not only density)
- add `FluidLoader(species, density, temperature)`
- update examples to utilize new API, add `townsend-coefficient.jl` example