### PR TITLE
Remove unused impedances (assumes that the ports are matched)

### DIFF
--- a/src/sources.jl
+++ b/src/sources.jl
@@ -11,18 +11,15 @@ struct TEM <: WaveguideMode end
 
 struct CoaxialPort <: BoundaryCondition
   signal :: TemporalFunction
-  η :: Float64
 end
 
 struct WaveguidePort <: BoundaryCondition
   signal :: TemporalFunction
   mode :: WaveguideMode
-  η :: Float64
 end
 
 struct UniformPort <: BoundaryCondition
   signal :: TemporalFunction
-  η :: Float64
 end
 
 struct CurrentSource <: BoundaryCondition


### PR DESCRIPTION
Maybe at some point we would like to connect a mismatched-impedance. But not today.